### PR TITLE
Use textarea for reason in Request a Jira account

### DIFF
--- a/htdocs/jira-account.html
+++ b/htdocs/jira-account.html
@@ -36,7 +36,7 @@
         <label for="why" class="form-label">Tell us a little about what you intend to use this account for.
             <br>N.B. You do NOT need an account to view existing Jira issues.
         </label>
-        <input type="text" class="form-control" id="why" name="why" aria-describedby="whyHelp">
+        <textarea class="form-control" id="why" name="why" aria-describedby="whyHelp"></textarea>
         <div id="whyHelp" class="form-text">Adding a proper description of your intended use for this account will assist the project in reviewing this request.</div>
     </div>
 


### PR DESCRIPTION
Input field with one line can limit users to write a little more about reason why JIRA account is needed.