### PR TITLE
Improving the Jira account creation form for 'blocked' projects

### DIFF
--- a/htdocs/jira-account.html
+++ b/htdocs/jira-account.html
@@ -12,40 +12,40 @@
 <form onsubmit="jira_account_request_submit(this); return false;">
     <div class="mb-3">
         <label for="project" class="form-label">For which ASF project do you want to file a ticket?</label>
-        <select class="form-control" id="project" name="project" aria-describedby="projectHelp">
+        <select class="form-control" id="project" name="project" aria-describedby="projectHelp" onchange="jira_check_project(this.value)">
             <option selected disabled value="">--- Select a project ---</option>
         </select>
         <div id="projectHelp" class="form-text">Select the ASF project you will initially be contributing to with this account. Make sure you have selected the correct project, and that they are using Jira for issue management, as the project will be reviewing your account request. Once your account is approved, you can use it to submit Jira tickets for other ASF projects and the Infrastructure team as well.</div>
     </div>
     <div class="mb-3">
         <label for="email" class="form-label">Email address</label>
-        <input type="email" class="form-control" id="email" name="email" aria-describedby="emailHelp">
+        <input type="email" class="form-control project-dependent" id="email" name="email" aria-describedby="emailHelp">
         <div id="emailHelp" class="form-text">We'll never share your email with anyone else. Please ensure this email address is correct, as we will use it to verify your request.</div>
     </div>
     <div class="mb-3">
         <label for="username" class="form-label">Desired user name</label>
-        <input type="text" class="form-control" id="username" name="username" aria-describedby="usernameHelp">
+        <input type="text" class="form-control project-dependent" id="username" name="username" aria-describedby="usernameHelp">
         <div id="usernameHelp" class="form-text">Your user name must be between 4 and 20 characters long.</div>
     </div>
     <div class="mb-3">
         <label for="realname" class="form-label">Your real (public) name</label>
-        <input type="text" class="form-control" id="realname" name="realname" aria-describedby="realnameHelp">
+        <input type="text" class="form-control project-dependent" id="realname" name="realname" aria-describedby="realnameHelp">
         <div id="realnameHelp" class="form-text">This is your actual name, as it will appear on Jira tickets you submit.</div>
     </div>
     <div class="mb-3">
         <label for="why" class="form-label">Tell us a little about what you intend to use this account for.
             <br>N.B. You do NOT need an account to view existing Jira issues.
         </label>
-        <textarea class="form-control" id="why" name="why" aria-describedby="whyHelp"></textarea>
+        <textarea class="form-control project-dependent" id="why" name="why" aria-describedby="whyHelp"></textarea>
         <div id="whyHelp" class="form-text">Adding a proper description of your intended use for this account will assist the project in reviewing this request.</div>
     </div>
 
     <div class="mb-3 form-check">
-        <input type="checkbox" class="form-check-input" name="verify" id="verify" value="agree">
+        <input type="checkbox" class="form-check-input project-dependent" name="verify" id="verify" value="agree">
         <label class="form-check-label" for="verify">I agree to let the project for which I am requesting an account review my public data.</label>
         <div id="verifyHelp" class="form-text">We will share your user name, public name, and reason for requesting an account with the project you specify, but will <em>not</em> share your email address.</div>
     </div>
-    <button type="submit" class="btn btn-primary">Submit</button>
+    <button type="submit" class="btn btn-primary project-dependent">Submit</button>
 </form>
 
 

--- a/htdocs/jira-account.html
+++ b/htdocs/jira-account.html
@@ -11,6 +11,13 @@
 
 <form onsubmit="jira_account_request_submit(this); return false;">
     <div class="mb-3">
+        <label for="project" class="form-label">For which ASF project do you want to file a ticket?</label>
+        <select class="form-control" id="project" name="project" aria-describedby="projectHelp">
+            <option selected disabled value="">--- Select a project ---</option>
+        </select>
+        <div id="projectHelp" class="form-text">Select the ASF project you will initially be contributing to with this account. Make sure you have selected the correct project, and that they are using Jira for issue management, as the project will be reviewing your account request. Once your account is approved, you can use it to submit Jira tickets for other ASF projects and the Infrastructure team as well.</div>
+    </div>
+    <div class="mb-3">
         <label for="email" class="form-label">Email address</label>
         <input type="email" class="form-control" id="email" name="email" aria-describedby="emailHelp">
         <div id="emailHelp" class="form-text">We'll never share your email with anyone else. Please ensure this email address is correct, as we will use it to verify your request.</div>
@@ -24,13 +31,6 @@
         <label for="realname" class="form-label">Your real (public) name</label>
         <input type="text" class="form-control" id="realname" name="realname" aria-describedby="realnameHelp">
         <div id="realnameHelp" class="form-text">This is your actual name, as it will appear on Jira tickets you submit.</div>
-    </div>
-    <div class="mb-3">
-        <label for="project" class="form-label">For which ASF project do you want to file a ticket?</label>
-        <select class="form-control" id="project" name="project" aria-describedby="projectHelp">
-            <option selected disabled value="">--- Select a project ---</option>
-        </select>
-        <div id="projectHelp" class="form-text">Select the ASF project you will initially be contributing to with this account. Make sure you have selected the correct project, and that they are using Jira for issue management, as the project will be reviewing your account request. Once your account is approved, you can use it to submit Jira tickets for other ASF projects and the Infrastructure team as well.</div>
     </div>
     <div class="mb-3">
         <label for="why" class="form-label">Tell us a little about what you intend to use this account for.

--- a/htdocs/js/selfserve.js
+++ b/htdocs/js/selfserve.js
@@ -177,6 +177,28 @@ async function jira_seed_project_list() {
   }
 }
 
+async function jira_check_project(project_name) {
+  const apiresp = await GET("/api/jira-project-blocked", {"project": project_name});
+  const apidata = await apiresp.json();
+  if (apidata.blocked === "True") {
+    toast("The project you have selected does not use Jira for issue tracking. Please contact the project to find out where to submit issues.");
+    jira_account_inputs_state("disabled");
+  } else {
+    jira_account_inputs_state("enabled");
+  }
+}
+
+function jira_account_inputs_state(desiredState) {
+  const form_elements = document.getElementsByClassName("project-dependent");
+  for (e of form_elements) {
+    if (desiredState === "disabled") {
+      e.disabled = true;
+    } else {
+      e.disabled = false;
+    }
+  }
+}
+
 async function jira_account_request_submit(form) {
   const formdata = new FormData(form);
   if (formdata.get("verify") !== "agree") {

--- a/server/app/endpoints/jiraaccount.py
+++ b/server/app/endpoints/jiraaccount.py
@@ -122,6 +122,16 @@ async def check_user_exists(form_data):
         return {"found": False}
 
 
+@middleware.rate_limited
+async def check_project_blocked(form_data):
+    """Checks if a project is 'blocked', meaning it doesn't use JIRA"""
+    project = form_data.get("project")
+    if project and JIRA_DB.fetchone("blocked", project=project):
+        return {"blocked": True}
+    else:
+        return {"blocked": False}
+
+
 async def process(form_data):
 
     # Submit application
@@ -358,7 +368,13 @@ quart.current_app.add_url_rule(
     ],
     view_func=middleware.glued(check_user_exists),
 )
-
+quart.current_app.add_url_rule(
+    "/api/jira-project-blocked",
+    methods=[
+        "GET",
+    ],
+    view_func=middleware.glued(check_project_blocked),
+)
 quart.current_app.add_url_rule(
     "/api/jira-account-review",
     methods=[


### PR DESCRIPTION
We should inform users sooner in the UX chain that their request will be denied if the project they are seeking an account with doesn't use Jira for issues.