### PR TITLE
INFRA-27451: Add option to send message upon Approval of new JIRA account request

### DIFF
--- a/htdocs/jira-account-review.html
+++ b/htdocs/jira-account-review.html
@@ -23,19 +23,26 @@
     </div>
     <input type="hidden" id="token" name="token">
     <div id="buttons_real">
-        <button type="button" onclick="jira_account_approve(this.form, 'approve');" class="btn btn-primary">Approve request</button>
-        <button type="button" onclick="jira_account_deny_details();" class="btn btn-danger">Deny request</button>
-        <p>
-        (You can provide a reason for rejection after pressing the Deny button)
-        </p>
+        <button type="button" onclick="jira_account_show_details('approve');" class="btn btn-primary">Approve request</button>
+        <button type="button" onclick="jira_account_show_details('deny');" class="btn btn-danger">Deny request</button>
+    </div>
+    <div id="approve_details" style="display: none;">
+        <div class="mb-3">
+            <label for="approve_reason" class="form-label">Optional message for the requester</label>
+            <textarea class="form-control" id="approve_reason" name="approve_reason" aria-describedby="approveHelp"></textarea>
+            <div id="approveHelp" class="form-text">You can optionally add a message that will be sent to the requester along with the approval notification.</div>
+        </div>
+        <button type="button" onclick="jira_account_approve(this.form, 'approve');" class="btn btn-primary">Confirm Approval</button>
+        <button type="button" onclick="jira_account_hide_details();show_main_buttons();" class="btn btn-secondary">Cancel</button>
     </div>
     <div id="deny_details" style="display: none;">
         <div class="mb-3">
-            <label for="reason" class="form-label">Optional reason for denying the request</label>
-            <textarea class="form-control" id="reason" name="reason" aria-describedby="reasonHelp"></textarea>
-            <div id="reasonHelp" class="form-text">If you wish to supply a reason for denying this request, do so here. We will send the reason to both the project and the requester.</div>
+            <label for="deny_reason" class="form-label">Optional reason for denying the request</label>
+            <textarea class="form-control" id="deny_reason" name="deny_reason" aria-describedby="denyHelp"></textarea>
+            <div id="denyHelp" class="form-text">You can optionally provide a reason for denying this request. This will be sent to both the project and the requester.</div>
         </div>
-        <button type="button" onclick="jira_account_approve(this.form, 'deny');"  class="btn btn-danger">Deny request</button>
+        <button type="button" onclick="jira_account_approve(this.form, 'deny');" class="btn btn-danger">Confirm Denial</button>
+        <button type="button" onclick="jira_account_hide_details();show_main_buttons();" class="btn btn-secondary">Cancel</button>
     </div>
     <div id="buttons_spin" style="display: none;">
         <button class="btn btn-primary" type="button" disabled>

--- a/htdocs/js/selfserve.js
+++ b/htdocs/js/selfserve.js
@@ -253,34 +253,74 @@ async function jira_account_review(prefs, qs) {
 
 async function jira_account_approve(form, verdict = "deny") {
   // Approve or deny a jira account request
-  const data = new FormData(form)
+  const data = new FormData(form);
   data.set("action", verdict);
-  // Hide deny details panel and buttons
-  const deny_details = document.getElementById('deny_details');
-  deny_details.style.display = "none";
-  const btns = document.getElementById('buttons_real');
-  btns.style.display = "none";
+  
+  // Get the appropriate reason based on verdict
+  const reasonField = verdict === 'approve' ? 'approve_reason' : 'deny_reason';
+  const reason = form.querySelector(`#${reasonField}`).value;
+  if (reason) {
+    data.set("reason", reason);
+  }
+  
+  // Hide all detail sections and buttons
+  jira_account_hide_details();
+  hide_main_buttons();
+  
   // Show spinner
   const spin = document.getElementById('buttons_spin');
   spin.style.display = "block";
-  const resp = await POST("/api/jira-account-review", {data: data})
-  const result = await resp.json();
-  if (result.success) {
-    const container = document.getElementById('contents');
-    container.innerText = result.message;
-  } else {
-    toast(result.message);
-    // Put back buttons, hide spinner
-    btns.style.display = "block";
+  
+  try {
+    const resp = await POST("/api/jira-account-review", {data: data});
+    const result = await resp.json();
+    
+    if (result.success) {
+      const container = document.getElementById('contents');
+      container.innerText = result.message;
+    } else {
+      toast(result.message);
+      // Reset UI to a consistent state
+      jira_account_hide_details();
+      show_main_buttons();
+    }
+  } catch (error) {
+    toast("An error occurred while processing your request. Please try again.");
+    // Reset UI to a consistent state
+    jira_account_hide_details();
+    show_main_buttons();
+  } finally {
+    // Always hide spinner
     spin.style.display = "none";
   }
 }
 
-function jira_account_deny_details() {
-  const real_buttons = document.getElementById('buttons_real');
-  real_buttons.style.display = "none";
-  const deny_details = document.getElementById('deny_details');
-  deny_details.style.display = "block";
+function jira_account_show_details(action) {
+  // Hide main buttons
+  hide_main_buttons();
+  
+  // Show the appropriate details section based on action
+  if (action === 'approve') {
+    document.getElementById('approve_details').style.display = 'block';
+  } else if (action === 'deny') {
+    document.getElementById('deny_details').style.display = 'block';
+  }
+}
+
+function jira_account_hide_details() {
+  // Hide all detail sections
+  document.getElementById('approve_details').style.display = 'none';
+  document.getElementById('deny_details').style.display = 'none';
+}
+
+function show_main_buttons() {
+  // Show main buttons
+  document.getElementById('buttons_real').style.display = 'block';
+}
+
+function hide_main_buttons() {
+  // Hide main buttons
+  document.getElementById('buttons_real').style.display = 'none';
 }
 
 async function jira_account_reactivate_submit(form) {
@@ -416,8 +456,7 @@ async function confluence_account_approve(form, verdict = "deny") {
   // Hide deny details panel and buttons
   const deny_details = document.getElementById('deny_details');
   deny_details.style.display = "none";
-  const btns = document.getElementById('buttons_real');
-  btns.style.display = "none";
+  hide_main_buttons();
   // Show spinner
   const spin = document.getElementById('buttons_spin');
   spin.style.display = "block";
@@ -429,14 +468,13 @@ async function confluence_account_approve(form, verdict = "deny") {
   } else {
     toast(result.message);
     // Put back buttons, hide spinner
-    btns.style.display = "block";
+    show_main_buttons();
     spin.style.display = "none";
   }
 }
 
 function confluence_account_deny_details() {
-  const real_buttons = document.getElementById('buttons_real');
-  real_buttons.style.display = "none";
+  hide_main_buttons();
   const deny_details = document.getElementById('deny_details');
   deny_details.style.display = "block";
 }
@@ -555,8 +593,7 @@ async function confluence_archive(form) {
   }
 
   // Set spinner, hide real button
-  const buttons = document.getElementById('buttons_real');
-  buttons.style.display = "none";
+  hide_main_buttons();
   const spin = document.getElementById('buttons_spin');
   spin.style.display = "block";
 
@@ -572,7 +609,7 @@ async function confluence_archive(form) {
   } else {
     toast(result.message);
     // hide spinner, put button back
-    buttons.style.display = "block";
+    show_main_buttons();
     spin.style.display = "none";
   }
 }
@@ -590,8 +627,7 @@ async function confluence_create(form) {
   }
 
   // Set spinner, hide real button
-  const buttons = document.getElementById('buttons_real');
-  buttons.style.display = "none";
+  hide_main_buttons();
   const spin = document.getElementById('buttons_spin');
   spin.style.display = "block";
 
@@ -609,7 +645,7 @@ async function confluence_create(form) {
   } else {
     toast(result.message);
     // hide spinner, put button back
-    buttons.style.display = "block";
+    show_main_buttons();
     spin.style.display = "none";
   }
 }
@@ -638,8 +674,7 @@ async function jira_create(form) {
   const data = new FormData(form);
 
   // Set spinner, hide real button
-  const buttons = document.getElementById('buttons_real');
-  buttons.style.display = "none";
+  hide_main_buttons();
   const spin = document.getElementById('buttons_spin');
   spin.style.display = "block";
 
@@ -653,7 +688,7 @@ async function jira_create(form) {
   } else {
     toast(result.message);
     // hide spinner, put button back
-    buttons.style.display = "block";
+    show_main_buttons();
     spin.style.display = "none";
   }
 }

--- a/server/app/endpoints/jiraaccount.py
+++ b/server/app/endpoints/jiraaccount.py
@@ -363,6 +363,9 @@ async def process_review():
             JIRA_DB.delete("pending", token=token)
             JIRA_DB.insert("users", {"userid": entry["userid"]})
 
+            # Add optional reason for approving
+            entry["reason"] = form_data.get("reason") or ""
+
             # Send welcome email
             email.from_template("jira_account_welcome.txt",
                                 recipient=entry["email"],

--- a/server/email_templates/jira_account_welcome.txt
+++ b/server/email_templates/jira_account_welcome.txt
@@ -4,6 +4,9 @@ Hi, there.
 
 As requested by the {project} project, we have created a Jira user account, {userid}, for you to use when reporting issues related to The Apache Software Foundation's projects or products.
 
+Message from the approver:
+{reason}
+
 Go to https://issues.apache.org/jira/secure/ForgotLoginDetails.jspa
 and select to have your password emailed to you.
 

--- a/server/email_templates/jira_account_welcome_pmc.txt
+++ b/server/email_templates/jira_account_welcome_pmc.txt
@@ -7,5 +7,8 @@ As approved by {approver}@apache.org, a new Jira user account, {userid}, has bee
 They provided the public name: {realname}
 and the reason: {why}
 
+Message from the approver:
+{reason}
+
 An email has been sent to the email address provided and this new user will
 need to reset their password before logging in for the first time.


### PR DESCRIPTION
When a JIRA account request is submitted, the approver currently has no way to send a message to the new account owner.

To support this, we need an option to include a message when approving the account (similar to how a rejection can include an explanation).