### PR TITLE
Add an informational banner on the cwiki account review page on the c…

### DIFF
--- a/htdocs/confluence-account-review.html
+++ b/htdocs/confluence-account-review.html
@@ -1,8 +1,7 @@
 <h1>Review Confluence account request</h1>
 
 <div class="alert alert-warning">
-    NOTE: There is currently a known issue with a tool which is used by the new Cwiki account automation which will result
-    in an error on approval and the account will not be created. However, Infra are reviewing the logs routinely and will manually create the account based on the log information until this tool issue is resolved.
+    NOTE: There is currently a known issue with a tool which is used by the new Cwiki account automation which will result in an error on approval and the account will not be created. However, Infra are reviewing the logs routinely and will manually create the account based on the log information until this tool issue is resolved.
 </div>
 
 <form onsubmit="confluence_account_request_submit(this); return false;">

--- a/htdocs/confluence-account-review.html
+++ b/htdocs/confluence-account-review.html
@@ -1,5 +1,10 @@
 <h1>Review Confluence account request</h1>
 
+<div class="alert alert-warning">
+    NOTE: There is currently a known issue with a tool which is used by the new Cwiki account automation which will result
+    in an error on approval and the account will not be created. However, Infra are reviewing the logs routinely and will manually create the account based on the log information until this tool issue is resolved.
+</div>
+
 <form onsubmit="confluence_account_request_submit(this); return false;">
     <div class="mb-3">
         <label for="project" class="form-label">Project</label>


### PR DESCRIPTION
…urrent acli issue

NFRA-28280 et al - acli version issue on cwiki causes an error on new cwiki account approval and the account is not created. Infra manually creating accounts for now and this message informs the user of the situation.